### PR TITLE
Update acknowledge method to expose subscription purchase

### DIFF
--- a/src/Subscriptions/Subscription.php
+++ b/src/Subscriptions/Subscription.php
@@ -59,12 +59,14 @@ class Subscription
 
     /**
      * @param string|null $developerPayload
+     * @return SubscriptionPurchase
      * @throws GuzzleException
      */
-    public function acknowledge(?string $developerPayload = null): void
+    public function acknowledge(?string $developerPayload = null): SubscriptionPurchase
     {
-        $isAcknowledged = $this->get()->getAcknowledgementState()->isAcknowledged();
-        if (! $isAcknowledged) {
+        $subscriptionPurchase = $this->get();
+
+        if (! $subscriptionPurchase->getAcknowledgementState()->isAcknowledged()) {
             $uri = sprintf(self::URI_ACKNOWLEDGE, $this->packageName, $this->subscriptionId, $this->token);
             $options = [
                 'form_params' => [
@@ -73,6 +75,8 @@ class Subscription
             ];
             $this->client->post($uri, $options);
         }
+
+        return $subscriptionPurchase;
     }
 
     /**


### PR DESCRIPTION
What?
Exposing subscription purchase data when acknowledging a purchase.

Why?
To further handle subscription purchase data after acknowledging without relying on server notifications only.

Open for input!

(Would use this as a base for the `laravel-in-app-purchase` repo to expose the data there further)

Cheers 👋