### PR TITLE
Payment state can be null

### DIFF
--- a/src/Subscriptions/SubscriptionPurchase.php
+++ b/src/Subscriptions/SubscriptionPurchase.php
@@ -354,7 +354,7 @@ class SubscriptionPurchase
     /**
      * @return int
      */
-    public function getPaymentState(): int
+    public function getPaymentState(): ?int
     {
         return $this->paymentState;
     }


### PR DESCRIPTION
The payment state of the subscription.
Not present for canceled, expired subscriptions.

https://developers.google.com/android-publisher/api-ref/rest/v3/purchases.subscriptions