### PR TITLE
[product] add consume method

### DIFF
--- a/src/Products/ProductClient.php
+++ b/src/Products/ProductClient.php
@@ -83,9 +83,7 @@ class ProductClient
     {
         $uri = $this->endpoint(self::URI_CONSUME);
 
-        $options = [];
-
-        return new EmptyResponse($this->client->post($uri, $options));
+        return new EmptyResponse($this->client->post($uri));
     }
 
     private function endpoint(string $template): string

--- a/src/Products/ProductClient.php
+++ b/src/Products/ProductClient.php
@@ -52,7 +52,7 @@ class ProductClient
      */
     public function get(): ProductPurchase
     {
-        $uri = $this->getEndpoint(self::URI_GET);
+        $uri = $this->endpoint(self::URI_GET);
 
         $response = $this->client->get($uri);
         $responseBody = json_decode((string)$response->getBody(), true);
@@ -65,7 +65,7 @@ class ProductClient
      */
     public function acknowledge(string $developerPayload = null): EmptyResponse
     {
-        $uri = $this->getEndpoint(self::URI_ACKNOWLEDGE);
+        $uri = $this->endpoint(self::URI_ACKNOWLEDGE);
 
         $options = [
             'form_params' => [
@@ -81,14 +81,14 @@ class ProductClient
      */
     public function consume(): EmptyResponse
     {
-        $uri = $this->getEndpoint(self::URI_CONSUME);
+        $uri = $this->endpoint(self::URI_CONSUME);
 
         $options = [];
 
         return new EmptyResponse($this->client->post($uri, $options));
     }
 
-    private function getEndpoint(string $template): string
+    private function endpoint(string $template): string
     {
         return sprintf($template, $this->packageName, $this->productId, $this->token);
     }

--- a/src/Products/ProductClient.php
+++ b/src/Products/ProductClient.php
@@ -14,6 +14,7 @@ class ProductClient
 {
     public const URI_GET = 'https://androidpublisher.googleapis.com/androidpublisher/v3/applications/%s/purchases/products/%s/tokens/%s';
     public const URI_ACKNOWLEDGE = 'https://androidpublisher.googleapis.com/androidpublisher/v3/applications/%s/purchases/products/%s/tokens/%s:acknowledge';
+    public const URI_CONSUME = 'https://androidpublisher.googleapis.com/androidpublisher/v3/applications/%s/purchases/products/%s/tokens/%s:consume';
 
     /**
      * @var ClientInterface
@@ -71,6 +72,22 @@ class ProductClient
                 'developerPayload' => $developerPayload,
             ],
         ];
+
+        return new EmptyResponse($this->client->post($uri, $options));
+    }
+
+
+    /**
+     * @throws GuzzleException
+     */
+    /**
+     * byme
+     */
+    public function consume(): EmptyResponse
+    {
+        $uri = $this->getEndpoint(self::URI_CONSUME);
+
+        $options = [];
 
         return new EmptyResponse($this->client->post($uri, $options));
     }

--- a/src/Products/ProductClient.php
+++ b/src/Products/ProductClient.php
@@ -76,12 +76,8 @@ class ProductClient
         return new EmptyResponse($this->client->post($uri, $options));
     }
 
-
     /**
      * @throws GuzzleException
-     */
-    /**
-     * byme
      */
     public function consume(): EmptyResponse
     {

--- a/tests/Products/ProductClientTest.php
+++ b/tests/Products/ProductClientTest.php
@@ -61,7 +61,7 @@ class ProductClientTest extends TestCase
 
         /** @var Request $request */
         $request = $transactions[0]['request'];
-        $this->assertEquals($this->getEndpoint(ProductClient::URI_GET), (string)$request->getUri());
+        $this->assertEquals($this->endpoint(ProductClient::URI_GET), (string)$request->getUri());
     }
 
     /**
@@ -87,10 +87,10 @@ class ProductClientTest extends TestCase
 
         /** @var Request $request */
         $request = $transactions[0]['request'];
-        $this->assertEquals($this->getEndpoint(ProductClient::URI_ACKNOWLEDGE), (string)$request->getUri());
+        $this->assertEquals($this->endpoint(ProductClient::URI_ACKNOWLEDGE), (string)$request->getUri());
     }
 
-    private function getEndpoint(string $template): string
+    private function endpoint(string $template): string
     {
         return sprintf($template, $this->packageName, $this->productId, $this->token);
     }

--- a/tests/Products/ProductClientTest.php
+++ b/tests/Products/ProductClientTest.php
@@ -90,6 +90,21 @@ class ProductClientTest extends TestCase
         $this->assertEquals($this->endpoint(ProductClient::URI_ACKNOWLEDGE), (string)$request->getUri());
     }
 
+    /** @test */
+    public function it_can_send_consume_request(): void
+    {
+        $response = new Response(200, [], '[]');
+        $transactions = [];
+        $client = ClientFactory::mock($response, $transactions);
+        $sut = new ProductClient($client, $this->packageName, $this->productId, $this->token);
+
+        $sut->consume();
+
+        /** @var Request $request */
+        $request = $transactions[0]['request'];
+        $this->assertEquals($this->endpoint(ProductClient::URI_CONSUME), (string)$request->getUri());
+    }
+
     private function endpoint(string $template): string
     {
         return sprintf($template, $this->packageName, $this->productId, $this->token);


### PR DESCRIPTION
New feature:
Add consume to google billing for consomable item

how to use it : 
$consumeitemGoogle = Product::googlePlay()->id($itemId)->token($purchaseToken)->consume();

Need change on repo laravel-in-app-purchases and google-play-billing