### PR TITLE
fix: use json guzzle request option instead of form_params

### DIFF
--- a/src/Subscriptions/SubscriptionClient.php
+++ b/src/Subscriptions/SubscriptionClient.php
@@ -86,7 +86,7 @@ class SubscriptionClient
     {
         $uri = $this->getEndpoint(self::URI_DEFER);
         $options = [
-            'form_params' => [
+            'json' => [
                 'deferralInfo' => $subscriptionDeferralInfo->toArray(),
             ],
         ];

--- a/tests/Subscriptions/SubscriptionClientTest.php
+++ b/tests/Subscriptions/SubscriptionClientTest.php
@@ -11,7 +11,6 @@ use Imdhemy\GooglePlay\Subscriptions\SubscriptionClient;
 use Imdhemy\GooglePlay\Subscriptions\SubscriptionPurchase;
 use Imdhemy\GooglePlay\ValueObjects\EmptyResponse;
 use Imdhemy\GooglePlay\ValueObjects\SubscriptionDeferralInfo;
-use Imdhemy\GooglePlay\ValueObjects\Time;
 use Tests\TestCase;
 
 class SubscriptionClientTest extends TestCase
@@ -113,10 +112,8 @@ class SubscriptionClientTest extends TestCase
 
     /**
      * @test
-     *
-     * @throws GuzzleException
      */
-    public function defer()
+    public function defer(): void
     {
         $desiredExpiryTimeMillis = $this->faker->dateTime->getTimestamp() * 1000;
         $deferResponse = new Response(200, [], json_encode(['newExpiryTimeMillis' => $desiredExpiryTimeMillis]));
@@ -128,11 +125,11 @@ class SubscriptionClientTest extends TestCase
         $deferralInfo = new SubscriptionDeferralInfo(0, $desiredExpiryTimeMillis);
         $newExpiryTime = $subscriptionClient->defer($deferralInfo);
 
-        $this->assertInstanceOf(Time::class, $newExpiryTime);
         $this->assertEquals($desiredExpiryTimeMillis, $newExpiryTime->getCarbon()->getTimestampMs());
 
         /** @var Request $request */
         $request = $transactions[0]['request'];
+        $this->assertEquals($deferralInfo->toArray(), json_decode($request->getBody()->getContents(), true)['deferralInfo']);
         $uri = $this->getEndpoint(SubscriptionClient::URI_DEFER);
         $this->assertEquals($uri, (string)$request->getUri());
     }


### PR DESCRIPTION
| Q             | A                                                                  |
|---------------|--------------------------------------------------------------------|
| Branch?       | 1.x                                             |
| Bug fix?      | yes                                                             |
| New feature?  | no                  |
| Deprecations? | no |
| Tickets       | Fix #101            |
| License       | MIT                                                                |

This fixes currently broken defer functionality (not clear if it's ever worked maybe the author owner can verify?)
