### PR TITLE
feat(purchase): support legacy subscription refund

### DIFF
--- a/src/Domain/Purchase/SubscriptionService.php
+++ b/src/Domain/Purchase/SubscriptionService.php
@@ -25,6 +25,11 @@ final readonly class SubscriptionService
     private const string LEGACY_DEFER_ENDPOINT = 'https://androidpublisher.googleapis.com/androidpublisher/v3/applications/{packageName}/purchases/subscriptions/{subscriptionId}/tokens/{token}:defer';
     private const string LEGACY_REFUND_ENDPOINT = 'https://androidpublisher.googleapis.com/androidpublisher/v3/applications/{packageName}/purchases/subscriptions/{subscriptionId}/tokens/{token}:refund';
 
+    private const array HEADERS = [
+        'Accept' => 'application/json',
+        'Content-Type' => 'application/json',
+    ];
+
     public function __construct(
         private ClientInterface $client,
         private NormalizerInterface $normalizer,
@@ -50,10 +55,7 @@ final readonly class SubscriptionService
         $request = new Request(
             method: 'POST',
             uri: $uri,
-            headers: [
-                'Accept' => 'application/json',
-                'Content-Type' => 'application/json',
-            ],
+            headers: self::HEADERS,
             body: $this->serializer->serialize(data: compact('revocationContext'))
         );
 
@@ -71,10 +73,7 @@ final readonly class SubscriptionService
         $request = new Request(
             method: 'POST',
             uri: $uri,
-            headers: [
-                'Accept' => 'application/json',
-                'Content-Type' => 'application/json',
-            ],
+            headers: self::HEADERS,
             body: $this->serializer->serialize(data: ['developerPayload' => $developerPayload])
         );
 
@@ -92,10 +91,7 @@ final readonly class SubscriptionService
         $request = new Request(
             method: 'POST',
             uri: $uri,
-            headers: [
-                'Accept' => 'application/json',
-                'Content-Type' => 'application/json',
-            ],
+            headers: self::HEADERS,
             body: $this->serializer->serialize(data: ['cancellationType' => $cancellationType->value])
         );
 
@@ -120,10 +116,7 @@ final readonly class SubscriptionService
         $request = new Request(
             method: 'POST',
             uri: $uri,
-            headers: [
-                'Accept' => 'application/json',
-                'Content-Type' => 'application/json',
-            ]
+            headers: self::HEADERS
         );
 
         $this->client->sendRequest($request);
@@ -140,10 +133,7 @@ final readonly class SubscriptionService
         $request = new Request(
             method: 'GET',
             uri: $uri,
-            headers: [
-                'Accept' => 'application/json',
-                'Content-Type' => 'application/json',
-            ]
+            headers: self::HEADERS
         );
 
         $response = $this->client->sendRequest($request);
@@ -162,10 +152,7 @@ final readonly class SubscriptionService
         $request = new Request(
             method: 'POST',
             uri: $uri,
-            headers: [
-                'Accept' => 'application/json',
-                'Content-Type' => 'application/json',
-            ],
+            headers: self::HEADERS,
             body: $this->serializer->serialize(data: ['deferralInfo' => $deferralInfo->toArray()])
         );
 

--- a/src/Domain/Purchase/SubscriptionService.php
+++ b/src/Domain/Purchase/SubscriptionService.php
@@ -23,6 +23,7 @@ final readonly class SubscriptionService
     private const string LEGACY_ACKNOWLEDGE_ENDPOINT = 'https://androidpublisher.googleapis.com/androidpublisher/v3/applications/{packageName}/purchases/subscriptions/tokens/{token}:acknowledge';
     private const string LEGACY_CANCEL_ENDPOINT = 'https://androidpublisher.googleapis.com/androidpublisher/v3/applications/{packageName}/purchases/subscriptions/tokens/{token}:cancel';
     private const string LEGACY_DEFER_ENDPOINT = 'https://androidpublisher.googleapis.com/androidpublisher/v3/applications/{packageName}/purchases/subscriptions/{subscriptionId}/tokens/{token}:defer';
+    private const string LEGACY_REFUND_ENDPOINT = 'https://androidpublisher.googleapis.com/androidpublisher/v3/applications/{packageName}/purchases/subscriptions/{subscriptionId}/tokens/{token}:refund';
 
     public function __construct(
         private ClientInterface $client,
@@ -106,6 +107,26 @@ final readonly class SubscriptionService
         $data = $this->doLegacyDefer($packageName, $subscriptionId, $token, $deferralInfo);
 
         return $this->normalizer->normalize(data: $data, type: DeferSubscriptionResponse::class);
+    }
+
+    public function legacyRefund(string $packageName, string $subscriptionId, string $token): void
+    {
+        $uri = str_replace(
+            search: ['{packageName}', '{subscriptionId}', '{token}'],
+            replace: [$packageName, $subscriptionId, $token],
+            subject: self::LEGACY_REFUND_ENDPOINT
+        );
+
+        $request = new Request(
+            method: 'POST',
+            uri: $uri,
+            headers: [
+                'Accept' => 'application/json',
+                'Content-Type' => 'application/json',
+            ]
+        );
+
+        $this->client->sendRequest($request);
     }
 
     private function doGet(string $packageName, string $token): array

--- a/tests/Domain/Purchase/SubscriptionServiceTest.php
+++ b/tests/Domain/Purchase/SubscriptionServiceTest.php
@@ -149,4 +149,29 @@ final class SubscriptionServiceTest extends TestCase
         );
         $this->assertEquals(new DeferSubscriptionResponse(new Time('1776004800000')), $actual);
     }
+
+    /** @test */
+    public function legacy_refund(): void
+    {
+        $history = [];
+        $client = $this->mockClient([new Response()], $history);
+        $packageName = 'com.example.app';
+        $subscriptionId = 'monthly001';
+        $token = $this->faker->subscriptionToken();
+        $sut = new SubscriptionService(client: $client, normalizer: $this->normalizer, serializer: $this->serializer);
+
+        $sut->legacyRefund($packageName, $subscriptionId, $token);
+
+        $this->assertClientSentRequest(
+            history: $history,
+            request: new Request(
+                method: 'POST',
+                uri: 'https://androidpublisher.googleapis.com/androidpublisher/v3/applications/'.$packageName.'/purchases/subscriptions/'.$subscriptionId.'/tokens/'.$token.':refund',
+                headers: [
+                    'Accept' => 'application/json',
+                    'Content-Type' => 'application/json',
+                ]
+            )
+        );
+    }
 }

--- a/tests/Domain/Purchase/SubscriptionServiceTest.php
+++ b/tests/Domain/Purchase/SubscriptionServiceTest.php
@@ -160,7 +160,11 @@ final class SubscriptionServiceTest extends TestCase
         $token = $this->faker->subscriptionToken();
         $sut = new SubscriptionService(client: $client, normalizer: $this->normalizer, serializer: $this->serializer);
 
-        $sut->legacyRefund($packageName, $subscriptionId, $token);
+        $sut->legacyRefund(
+            packageName: $packageName,
+            subscriptionId: $subscriptionId,
+            token: $token
+        );
 
         $this->assertClientSentRequest(
             history: $history,

--- a/tests/Domain/Purchase/SubscriptionServiceTest.php
+++ b/tests/Domain/Purchase/SubscriptionServiceTest.php
@@ -17,7 +17,7 @@ use Tests\TestCase;
 final class SubscriptionServiceTest extends TestCase
 {
     /** @test */
-    public function get_subscription(): void
+    public function get(): void
     {
         $history = [];
         $packageName = 'com.example.app';
@@ -41,7 +41,7 @@ final class SubscriptionServiceTest extends TestCase
     }
 
     /** @test */
-    public function revoke_subscription(): void
+    public function revoke(): void
     {
         $history = [];
         $packageName = 'com.example.app';
@@ -66,7 +66,7 @@ final class SubscriptionServiceTest extends TestCase
     }
 
     /** @test */
-    public function legacy_acknowledge_subscription(): void
+    public function legacy_acknowledge(): void
     {
         $history = [];
         $packageName = 'com.example.app';
@@ -92,7 +92,7 @@ final class SubscriptionServiceTest extends TestCase
     }
 
     /** @test */
-    public function legacy_cancel_subscription(): void
+    public function legacy_cancel(): void
     {
         $history = [];
         $packageName = 'com.example.app';
@@ -118,7 +118,7 @@ final class SubscriptionServiceTest extends TestCase
     }
 
     /** @test */
-    public function legacy_defer_subscription(): void
+    public function legacy_defer(): void
     {
         $history = [];
         $client = $this->mockClient([new Response(200, [], '{"newExpiryTimeMillis": "1776004800000"}')], $history);


### PR DESCRIPTION
| Q             | A                                                        |
|---------------|----------------------------------------------------------|
| Tickets       | Fix #247  <!-- prefix each issue number with "Fix #247", --> |
| License       | MIT                                                      |

In this MR, I've introduced the legacy purchases subscriptions `refund` method - the last legacy method - 

**Key changes:** 
1. `legacyRefund()` method has been added to `SubscriptionService`
2. `legacy_refund()` test case has been added to `SubscriptionServiceTest`


<!--
Replace this notice with a short README for your feature/bugfix.
This will help reviewers and should be a good start for the documentation.
-->
