### PR TITLE
fix(purchase): update `AutoRenewingPlan` to support optional values

### DIFF
--- a/src/Domain/Purchase/Subscription/AutoRenewingPlan.php
+++ b/src/Domain/Purchase/Subscription/AutoRenewingPlan.php
@@ -14,8 +14,8 @@ use Imdhemy\GooglePlay\ValueObjects\Money;
 final readonly class AutoRenewingPlan
 {
     public function __construct(
+        public Money $recurringPrice,
         public ?bool $autoRenewEnabled = false,
-        public ?Money $recurringPrice = null,
         public ?SubscriptionItemPriceChangeDetails $priceChangeDetails = null,
         public ?InstallmentPlan $installmentDetails = null,
     ) {

--- a/src/Domain/Purchase/Subscription/AutoRenewingPlan.php
+++ b/src/Domain/Purchase/Subscription/AutoRenewingPlan.php
@@ -14,10 +14,10 @@ use Imdhemy\GooglePlay\ValueObjects\Money;
 final readonly class AutoRenewingPlan
 {
     public function __construct(
-        public bool $autoRenewEnabled,
-        public Money $recurringPrice,
-        public SubscriptionItemPriceChangeDetails $priceChangeDetails,
-        public InstallmentPlan $installmentDetails,
+        public ?bool $autoRenewEnabled = false,
+        public ?Money $recurringPrice = null,
+        public ?SubscriptionItemPriceChangeDetails $priceChangeDetails = null,
+        public ?InstallmentPlan $installmentDetails = null,
     ) {
     }
 }

--- a/src/Domain/Purchase/Subscription/AutoRenewingPlan.php
+++ b/src/Domain/Purchase/Subscription/AutoRenewingPlan.php
@@ -15,7 +15,7 @@ final readonly class AutoRenewingPlan
 {
     public function __construct(
         public Money $recurringPrice,
-        public ?bool $autoRenewEnabled = false,
+        public ?bool $autoRenewEnabled = null,
         public ?SubscriptionItemPriceChangeDetails $priceChangeDetails = null,
         public ?InstallmentPlan $installmentDetails = null,
     ) {

--- a/tests/Domain/Purchase/Subscription/AutoRenewingPlanTest.php
+++ b/tests/Domain/Purchase/Subscription/AutoRenewingPlanTest.php
@@ -48,4 +48,23 @@ final class AutoRenewingPlanTest extends TestCase
         $this->assertInstanceOf(SubscriptionItemPriceChangeDetails::class, $actual->priceChangeDetails);
         $this->assertInstanceOf(InstallmentPlan::class, $actual->installmentDetails);
     }
+
+    /** @test */
+    public function instantiate_with_recurring_price_only(): void
+    {
+        $data = [
+            'recurringPrice' => [
+                'currencyCode' => $this->faker->currencyCode(),
+                'units' => (string)$this->faker->randomNumber(5),
+                'nanos' => $this->faker->randomNumber(5),
+            ],
+        ];
+
+        $actual = $this->normalizer->normalize($data, AutoRenewingPlan::class);
+        $this->assertInstanceOf(AutoRenewingPlan::class, $actual);
+        $this->assertFalse($actual->autoRenewEnabled);
+        $this->assertInstanceOf(Money::class, $actual->recurringPrice);
+        $this->assertNull($actual->priceChangeDetails);
+        $this->assertNull($actual->installmentDetails);
+    }
 }

--- a/tests/Domain/Purchase/Subscription/AutoRenewingPlanTest.php
+++ b/tests/Domain/Purchase/Subscription/AutoRenewingPlanTest.php
@@ -61,6 +61,7 @@ final class AutoRenewingPlanTest extends TestCase
         ];
 
         $actual = $this->normalizer->normalize($data, AutoRenewingPlan::class);
+
         $this->assertInstanceOf(AutoRenewingPlan::class, $actual);
         $this->assertFalse($actual->autoRenewEnabled);
         $this->assertInstanceOf(Money::class, $actual->recurringPrice);

--- a/tests/Domain/Purchase/Subscription/AutoRenewingPlanTest.php
+++ b/tests/Domain/Purchase/Subscription/AutoRenewingPlanTest.php
@@ -63,7 +63,7 @@ final class AutoRenewingPlanTest extends TestCase
         $actual = $this->normalizer->normalize($data, AutoRenewingPlan::class);
 
         $this->assertInstanceOf(AutoRenewingPlan::class, $actual);
-        $this->assertFalse($actual->autoRenewEnabled);
+        $this->assertNull($actual->autoRenewEnabled);
         $this->assertInstanceOf(Money::class, $actual->recurringPrice);
         $this->assertNull($actual->priceChangeDetails);
         $this->assertNull($actual->installmentDetails);


### PR DESCRIPTION
| Q             | A                                                        |
|---------------|----------------------------------------------------------|
| Tickets       | Fix #257 |
| License       | MIT                                                      |

### Updated
- updated constructor of [Domain\Purchase\Subscription\AutoRenewingPlan](https://github.com/imdhemy/google-play-billing/blob/1.x/src/Domain/Purchase/Subscription/AutoRenewingPlan.php)
- added test case

Closes #257 
