### PR TITLE
fix(notifications): fix creating subscription notification without subscription id

### DIFF
--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -89,7 +89,6 @@
     <MixedArgument>
       <code><![CDATA[$attributes['notificationType']]]></code>
       <code><![CDATA[$attributes['purchaseToken']]]></code>
-      <code><![CDATA[$attributes['subscriptionId']]]></code>
       <code><![CDATA[$attributes['version']]]></code>
     </MixedArgument>
   </file>

--- a/src/DeveloperNotifications/SubscriptionNotification.php
+++ b/src/DeveloperNotifications/SubscriptionNotification.php
@@ -57,7 +57,7 @@ class SubscriptionNotification implements NotificationPayload
         $this->version = $version;
         $this->notificationType = $notificationType;
         $this->purchaseToken = $purchaseToken;
-        $this->subscriptionId = $subscriptionId;
+        $this->subscriptionId = (string)$subscriptionId;
     }
 
     public static function create(array $attributes): SubscriptionNotification

--- a/src/DeveloperNotifications/SubscriptionNotification.php
+++ b/src/DeveloperNotifications/SubscriptionNotification.php
@@ -52,7 +52,7 @@ class SubscriptionNotification implements NotificationPayload
     /**
      * SubscriptionNotification constructor.
      */
-    public function __construct(string $version, int $notificationType, string $purchaseToken, string $subscriptionId)
+    public function __construct(string $version, int $notificationType, string $purchaseToken, ?string $subscriptionId = null)
     {
         $this->version = $version;
         $this->notificationType = $notificationType;
@@ -66,7 +66,7 @@ class SubscriptionNotification implements NotificationPayload
             $attributes['version'],
             $attributes['notificationType'],
             $attributes['purchaseToken'],
-            $attributes['subscriptionId']
+            $attributes['subscriptionId'] ?? null
         );
     }
 

--- a/src/DeveloperNotifications/SubscriptionNotification.php
+++ b/src/DeveloperNotifications/SubscriptionNotification.php
@@ -52,21 +52,21 @@ class SubscriptionNotification implements NotificationPayload
     /**
      * SubscriptionNotification constructor.
      */
-    public function __construct(string $version, int $notificationType, string $purchaseToken, ?string $subscriptionId = null)
+    public function __construct(string $version, int $notificationType, string $purchaseToken, string $subscriptionId)
     {
         $this->version = $version;
         $this->notificationType = $notificationType;
         $this->purchaseToken = $purchaseToken;
-        $this->subscriptionId = (string)$subscriptionId;
+        $this->subscriptionId = $subscriptionId;
     }
 
     public static function create(array $attributes): SubscriptionNotification
     {
         return new self(
-            $attributes['version'],
-            $attributes['notificationType'],
-            $attributes['purchaseToken'],
-            $attributes['subscriptionId'] ?? null
+            version: $attributes['version'],
+            notificationType: $attributes['notificationType'],
+            purchaseToken: $attributes['purchaseToken'],
+            subscriptionId: (string)($attributes['subscriptionId'] ?? null)
         );
     }
 

--- a/tests/DeveloperNotifications/SubscriptionNotificationTest.php
+++ b/tests/DeveloperNotifications/SubscriptionNotificationTest.php
@@ -76,6 +76,20 @@ class SubscriptionNotificationTest extends TestCase
     }
 
     #[Test]
+    public function test_create_without_subscription_id()
+    {
+        $data = [
+            'version' => $this->version,
+            'notificationType' => $this->notificationType,
+            'purchaseToken' => $this->purchaseToken,
+        ];
+
+        $payload = SubscriptionNotification::create($data);
+
+        $this->assertInstanceOf(SubscriptionNotification::class, $payload);
+    }
+
+    #[Test]
     public function test_get_version()
     {
         $payload = SubscriptionNotification::create($this->data);


### PR DESCRIPTION
| Q             | A                                                        |
|---------------|----------------------------------------------------------|
| Tickets       | Fix #274  |
| License       | MIT                                                      |

I've proposed this PR to fix creating SubscriptionNotification without `subscriptionId` as according to the issue, it's not always passed. 

**Key changes:** 
1. In `SubscriptionNotification::create` I check whether the `subscriptionId` exists.
2. I casted `subscriptionId` to be string anyways.
3. I added a new test case in `SubscriptionNotificationTest` to cover creating  a `SubscriptionNotification` without `subscriptionId`