### PR TITLE
fix(purchase): make expiryTime and offerDetails optional

### DIFF
--- a/src/Domain/Purchase/Subscription/SubscriptionPurchaseLineItem.php
+++ b/src/Domain/Purchase/Subscription/SubscriptionPurchaseLineItem.php
@@ -15,8 +15,8 @@ final readonly class SubscriptionPurchaseLineItem
 {
     public function __construct(
         public string $productId,
-        public Time $expiryTime,
-        public OfferDetails $offerDetails,
+        public ?Time $expiryTime,
+        public ?OfferDetails $offerDetails,
         public ?string $latestSuccessfulOrderId = null,
         public ?AutoRenewingPlan $autoRenewingPlan = null,
         public ?PrepaidPlan $prepaidPlan = null,

--- a/src/Domain/Purchase/Subscription/SubscriptionPurchaseLineItem.php
+++ b/src/Domain/Purchase/Subscription/SubscriptionPurchaseLineItem.php
@@ -15,8 +15,8 @@ final readonly class SubscriptionPurchaseLineItem
 {
     public function __construct(
         public string $productId,
-        public ?Time $expiryTime,
-        public ?OfferDetails $offerDetails,
+        public ?Time $expiryTime = null,
+        public ?OfferDetails $offerDetails = null,
         public ?string $latestSuccessfulOrderId = null,
         public ?AutoRenewingPlan $autoRenewingPlan = null,
         public ?PrepaidPlan $prepaidPlan = null,

--- a/tests/Domain/Purchase/Subscription/SubscriptionPurchaseLineItemTest.php
+++ b/tests/Domain/Purchase/Subscription/SubscriptionPurchaseLineItemTest.php
@@ -11,7 +11,7 @@ use Tests\TestCase;
 final class SubscriptionPurchaseLineItemTest extends TestCase
 {
     #[Test]
-    public function instantiate_with_auto_renewing_plan(): void
+    public function instantiation_with_all_props(): void
     {
         $data = [
             'productId' => $this->faker->word(),
@@ -46,6 +46,12 @@ final class SubscriptionPurchaseLineItemTest extends TestCase
                 'basePlanId' => $this->faker->word(),
                 'offerId' => $this->faker->word(),
             ],
+            'prepaidPlan' => [
+                'allowExtendAfterTime' => '2014-10-02T15:01:23Z',
+            ],
+            'deferredItemReplacement' => [
+                'productId' => $this->faker->word(),
+            ],
             'signupPromotion' => [
                 'oneTimeCode' => [],
             ],
@@ -57,11 +63,15 @@ final class SubscriptionPurchaseLineItemTest extends TestCase
         $this->assertSame($data['expiryTime'], $actual->expiryTime->originalValue);
         $this->assertSame($data['latestSuccessfulOrderId'], $actual->latestSuccessfulOrderId);
         $this->assertNotNull($actual->autoRenewingPlan);
-        $this->assertNull($actual->prepaidPlan);
+        $this->assertNotNull($actual->prepaidPlan);
+        $this->assertSame(
+            $data['prepaidPlan']['allowExtendAfterTime'],
+            $actual->prepaidPlan->allowExtendAfterTime->originalValue
+        );
         $this->assertSame($data['offerDetails']['offerTags'], $actual->offerDetails->offerTags);
         $this->assertSame($data['offerDetails']['basePlanId'], $actual->offerDetails->basePlanId);
         $this->assertSame($data['offerDetails']['offerId'], $actual->offerDetails->offerId);
-        $this->assertNull($actual->deferredItemReplacement);
+        $this->assertSame($data['deferredItemReplacement']['productId'], $actual->deferredItemReplacement->productId);
         $this->assertNotNull($actual->signupPromotion);
         $this->assertNotNull($actual->signupPromotion->oneTimeCode);
         $this->assertSame(
@@ -116,44 +126,6 @@ final class SubscriptionPurchaseLineItemTest extends TestCase
     }
 
     #[Test]
-    public function instantiate_with_prepaid_plan_and_deferred_item_replacement(): void
-    {
-        $data = [
-            'productId' => $this->faker->word(),
-            'expiryTime' => '2014-10-02T15:01:23Z',
-            'latestSuccessfulOrderId' => $this->faker->uuid(),
-            'prepaidPlan' => [
-                'allowExtendAfterTime' => '2014-10-02T15:01:23Z',
-            ],
-            'offerDetails' => [
-                'offerTags' => [$this->faker->word()],
-                'basePlanId' => $this->faker->word(),
-                'offerId' => $this->faker->word(),
-            ],
-            'deferredItemReplacement' => [
-                'productId' => $this->faker->word(),
-            ],
-        ];
-
-        $actual = $this->normalizer->normalize($data, SubscriptionPurchaseLineItem::class);
-
-        $this->assertSame($data['productId'], $actual->productId);
-        $this->assertSame($data['expiryTime'], $actual->expiryTime->originalValue);
-        $this->assertSame($data['latestSuccessfulOrderId'], $actual->latestSuccessfulOrderId);
-        $this->assertNull($actual->autoRenewingPlan);
-        $this->assertNotNull($actual->prepaidPlan);
-        $this->assertSame(
-            $data['prepaidPlan']['allowExtendAfterTime'],
-            $actual->prepaidPlan->allowExtendAfterTime->originalValue
-        );
-        $this->assertSame($data['offerDetails']['offerTags'], $actual->offerDetails->offerTags);
-        $this->assertSame($data['offerDetails']['basePlanId'], $actual->offerDetails->basePlanId);
-        $this->assertSame($data['offerDetails']['offerId'], $actual->offerDetails->offerId);
-        $this->assertSame($data['deferredItemReplacement']['productId'], $actual->deferredItemReplacement->productId);
-        $this->assertNull($actual->signupPromotion);
-    }
-
-    #[Test]
     public function instantiation_with_required_fields(): void
     {
         $data = [
@@ -161,8 +133,8 @@ final class SubscriptionPurchaseLineItemTest extends TestCase
         ];
 
         $actual = $this->normalizer->normalize($data, SubscriptionPurchaseLineItem::class);
-        $this->assertSame($data['productId'], $actual->productId);
 
+        $this->assertSame($data['productId'], $actual->productId);
         $this->assertNull($actual->expiryTime);
         $this->assertNull($actual->offerDetails);
         $this->assertNull($actual->latestSuccessfulOrderId);

--- a/tests/Domain/Purchase/Subscription/SubscriptionPurchaseLineItemTest.php
+++ b/tests/Domain/Purchase/Subscription/SubscriptionPurchaseLineItemTest.php
@@ -152,4 +152,23 @@ final class SubscriptionPurchaseLineItemTest extends TestCase
         $this->assertSame($data['deferredItemReplacement']['productId'], $actual->deferredItemReplacement->productId);
         $this->assertNull($actual->signupPromotion);
     }
+
+    #[Test]
+    public function instantiation_with_required_fields(): void
+    {
+        $data = [
+            'productId' => $this->faker->word(),
+        ];
+
+        $actual = $this->normalizer->normalize($data, SubscriptionPurchaseLineItem::class);
+        $this->assertSame($data['productId'], $actual->productId);
+
+        $this->assertNull($actual->expiryTime);
+        $this->assertNull($actual->offerDetails);
+        $this->assertNull($actual->latestSuccessfulOrderId);
+        $this->assertNull($actual->autoRenewingPlan);
+        $this->assertNull($actual->prepaidPlan);
+        $this->assertNull($actual->deferredItemReplacement);
+        $this->assertNull($actual->signupPromotion);
+    }
 }


### PR DESCRIPTION
| Q             | A                                                        |
|---------------|----------------------------------------------------------|
| Tickets       | Fix #304  |
| License       | MIT                                                      |

Updated `expiryTime` and `offerDetails` of [SubscriptionPurchaseLineItem](https://github.com/BernhardtD/google-play-billing/blob/1.x/src/Domain/Purchase/Subscription/SubscriptionPurchaseLineItem.php) to be an optional parameters.
