### PR TITLE
feat(purchase): support subscription offer phase (#306)

### DIFF
--- a/src/Domain/Purchase/Subscription/OfferPhase.php
+++ b/src/Domain/Purchase/Subscription/OfferPhase.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Imdhemy\GooglePlay\Domain\Purchase\Subscription;
+
+use Imdhemy\GooglePlay\Domain\Purchase\Subscription\OfferPhase\BasePriceOfferPhase;
+use Imdhemy\GooglePlay\Domain\Purchase\Subscription\OfferPhase\FreeTrialOfferPhase;
+use Imdhemy\GooglePlay\Domain\Purchase\Subscription\OfferPhase\IntroductoryPriceOfferPhase;
+use Imdhemy\GooglePlay\Domain\Purchase\Subscription\OfferPhase\ProrationPeriodOfferPhase;
+
+/**
+ * Offer phase information related to a purchase line item.
+ *
+ * @see https://developers.google.com/android-publisher/api-ref/rest/v3/purchases.subscriptionsv2#offerphase
+ */
+final readonly class OfferPhase
+{
+    public function __construct(
+        public ?ProrationPeriodOfferPhase $prorationPeriod = null,
+        public ?FreeTrialOfferPhase $freeTrial = null,
+        public ?IntroductoryPriceOfferPhase $introductoryPrice = null,
+        public ?BasePriceOfferPhase $basePrice = null,
+    ) {
+    }
+}

--- a/src/Domain/Purchase/Subscription/OfferPhase/BasePriceOfferPhase.php
+++ b/src/Domain/Purchase/Subscription/OfferPhase/BasePriceOfferPhase.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Imdhemy\GooglePlay\Domain\Purchase\Subscription\OfferPhase;
+
+/**
+ * @see https://developers.google.com/android-publisher/api-ref/rest/v3/purchases.subscriptionsv2#basepriceofferphase
+ */
+final class BasePriceOfferPhase
+{
+}

--- a/src/Domain/Purchase/Subscription/OfferPhase/FreeTrialOfferPhase.php
+++ b/src/Domain/Purchase/Subscription/OfferPhase/FreeTrialOfferPhase.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Imdhemy\GooglePlay\Domain\Purchase\Subscription\OfferPhase;
+
+/**
+ * @see https://developers.google.com/android-publisher/api-ref/rest/v3/purchases.subscriptionsv2#freetrialofferphase
+ */
+final class FreeTrialOfferPhase
+{
+}

--- a/src/Domain/Purchase/Subscription/OfferPhase/IntroductoryPriceOfferPhase.php
+++ b/src/Domain/Purchase/Subscription/OfferPhase/IntroductoryPriceOfferPhase.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Imdhemy\GooglePlay\Domain\Purchase\Subscription\OfferPhase;
+
+/**
+ * @see https://developers.google.com/android-publisher/api-ref/rest/v3/purchases.subscriptionsv2#introductorypriceofferphase
+ */
+final class IntroductoryPriceOfferPhase
+{
+}

--- a/src/Domain/Purchase/Subscription/OfferPhase/OriginalOfferPhaseType.php
+++ b/src/Domain/Purchase/Subscription/OfferPhase/OriginalOfferPhaseType.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Imdhemy\GooglePlay\Domain\Purchase\Subscription\OfferPhase;
+
+/**
+ * @see https://developers.google.com/android-publisher/api-ref/rest/v3/purchases.subscriptionsv2#originalofferphasetype
+ */
+enum OriginalOfferPhaseType: string
+{
+    case UNSPECIFIED = 'ORIGINAL_OFFER_PHASE_TYPE_UNSPECIFIED';
+    case BASE = 'BASE';
+    case INTRODUCTORY = 'INTRODUCTORY';
+    case TRIAL = 'FREE_TRIAL';
+}

--- a/src/Domain/Purchase/Subscription/OfferPhase/OriginalOfferPhaseType.php
+++ b/src/Domain/Purchase/Subscription/OfferPhase/OriginalOfferPhaseType.php
@@ -12,5 +12,5 @@ enum OriginalOfferPhaseType: string
     case UNSPECIFIED = 'ORIGINAL_OFFER_PHASE_TYPE_UNSPECIFIED';
     case BASE = 'BASE';
     case INTRODUCTORY = 'INTRODUCTORY';
-    case TRIAL = 'FREE_TRIAL';
+    case FREE_TRIAL = 'FREE_TRIAL';
 }

--- a/src/Domain/Purchase/Subscription/OfferPhase/ProrationPeriodOfferPhase.php
+++ b/src/Domain/Purchase/Subscription/OfferPhase/ProrationPeriodOfferPhase.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Imdhemy\GooglePlay\Domain\Purchase\Subscription\OfferPhase;
+
+/**
+ * Offer phase information related to a purchase line item.
+ *
+ * @see https://developers.google.com/android-publisher/api-ref/rest/v3/purchases.subscriptionsv2#prorationperiodofferphase
+ */
+final readonly class ProrationPeriodOfferPhase
+{
+    public function __construct(public OriginalOfferPhaseType $originalOfferPhaseType)
+    {
+    }
+}

--- a/src/Domain/Purchase/Subscription/OfferPhase/ProrationPeriodOfferPhase.php
+++ b/src/Domain/Purchase/Subscription/OfferPhase/ProrationPeriodOfferPhase.php
@@ -11,7 +11,7 @@ namespace Imdhemy\GooglePlay\Domain\Purchase\Subscription\OfferPhase;
  */
 final readonly class ProrationPeriodOfferPhase
 {
-    public function __construct(public OriginalOfferPhaseType $originalOfferPhaseType)
+    public function __construct(public ?OriginalOfferPhaseType $originalOfferPhaseType = null)
     {
     }
 }

--- a/src/Domain/Purchase/Subscription/SubscriptionPurchaseLineItem.php
+++ b/src/Domain/Purchase/Subscription/SubscriptionPurchaseLineItem.php
@@ -22,6 +22,7 @@ final readonly class SubscriptionPurchaseLineItem
         public ?PrepaidPlan $prepaidPlan = null,
         public ?DeferredItemReplacement $deferredItemReplacement = null,
         public ?SignupPromotion $signupPromotion = null,
+        public ?OfferPhase $offerPhase = null,
     ) {
     }
 }

--- a/tests/Domain/Purchase/Entity/SubscriptionPurchaseTest.php
+++ b/tests/Domain/Purchase/Entity/SubscriptionPurchaseTest.php
@@ -7,6 +7,8 @@ namespace Tests\Domain\Purchase\Entity;
 use Imdhemy\GooglePlay\Domain\Purchase\Entity\SubscriptionPurchase;
 use Imdhemy\GooglePlay\Domain\Purchase\Subscription\AcknowledgementState;
 use Imdhemy\GooglePlay\Domain\Purchase\Subscription\ExternalAccountIdentifiers;
+use Imdhemy\GooglePlay\Domain\Purchase\Subscription\OfferPhase;
+use Imdhemy\GooglePlay\Domain\Purchase\Subscription\OfferPhase\FreeTrialOfferPhase;
 use Imdhemy\GooglePlay\Domain\Purchase\Subscription\SubscribeWithGoogleInfo;
 use Imdhemy\GooglePlay\Domain\Purchase\Subscription\SubscriptionPurchaseLineItem;
 use Imdhemy\GooglePlay\Domain\Purchase\Subscription\SubscriptionState;
@@ -33,6 +35,9 @@ final class SubscriptionPurchaseTest extends TestCase
                         'offerTags' => [$this->faker->word()],
                         'basePlanId' => $this->faker->word(),
                         'offerId' => $this->faker->word(),
+                    ],
+                    'offerPhase' => [
+                        'freeTrial' => [],
                     ],
                     'deferredItemReplacement' => [
                         'productId' => $this->faker->word(),
@@ -65,6 +70,8 @@ final class SubscriptionPurchaseTest extends TestCase
         $this->assertSame($data['kind'], $actual->kind);
         $this->assertSame($data['regionCode'], $actual->regionCode);
         $this->assertInstanceOf(SubscriptionPurchaseLineItem::class, $actual->lineItems[0]);
+        $this->assertInstanceOf(OfferPhase::class, $actual->lineItems[0]->offerPhase);
+        $this->assertInstanceOf(FreeTrialOfferPhase::class, $actual->lineItems[0]->offerPhase->freeTrial);
         $this->assertEquals($data['startTime'], $actual->startTime?->originalValue);
         $this->assertEquals($data['subscriptionState'], $actual->subscriptionState->value);
         $this->assertSame($data['linkedPurchaseToken'], $actual->linkedPurchaseToken);

--- a/tests/Domain/Purchase/Subscription/OfferPhaseTest.php
+++ b/tests/Domain/Purchase/Subscription/OfferPhaseTest.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Domain\Purchase\Subscription;
+
+use Imdhemy\GooglePlay\Domain\Purchase\Subscription\OfferPhase;
+use Imdhemy\GooglePlay\Domain\Purchase\Subscription\OfferPhase\OriginalOfferPhaseType;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+final class OfferPhaseTest extends TestCase
+{
+    #[Test]
+    public function instantiate_proration_period_offer(): void
+    {
+        $actual = $this->normalizer->normalize(['prorationPeriod' => [
+            'originalOfferPhaseType' => OriginalOfferPhaseType::INTRODUCTORY->value,
+        ]], OfferPhase::class);
+
+        $this->assertInstanceOf(OfferPhase::class, $actual);
+        $this->assertNotNull($actual->prorationPeriod);
+        $this->assertEquals(OriginalOfferPhaseType::INTRODUCTORY, $actual->prorationPeriod->originalOfferPhaseType);
+        $this->assertNull($actual->freeTrial);
+        $this->assertNull($actual->introductoryPrice);
+        $this->assertNull($actual->basePrice);
+    }
+
+    #[Test]
+    public function instantiate_free_trial_offer(): void
+    {
+        $actual = $this->normalizer->normalize(['freeTrial' => []], OfferPhase::class);
+
+        $this->assertInstanceOf(OfferPhase::class, $actual);
+        $this->assertNotNull($actual->freeTrial);
+        $this->assertNull($actual->prorationPeriod);
+        $this->assertNull($actual->introductoryPrice);
+        $this->assertNull($actual->basePrice);
+    }
+
+    #[Test]
+    public function instantiate_introductory_price_offer(): void
+    {
+        $actual = $this->normalizer->normalize(['introductoryPrice' => []], OfferPhase::class);
+
+        $this->assertInstanceOf(OfferPhase::class, $actual);
+        $this->assertNotNull($actual->introductoryPrice);
+        $this->assertNull($actual->prorationPeriod);
+        $this->assertNull($actual->freeTrial);
+        $this->assertNull($actual->basePrice);
+    }
+
+    #[Test]
+    public function instantiate_base_price_offer(): void
+    {
+        $actual = $this->normalizer->normalize(['basePrice' => []], OfferPhase::class);
+
+        $this->assertInstanceOf(OfferPhase::class, $actual);
+        $this->assertNotNull($actual->basePrice);
+        $this->assertNull($actual->prorationPeriod);
+        $this->assertNull($actual->freeTrial);
+        $this->assertNull($actual->introductoryPrice);
+    }
+}

--- a/tests/Domain/Purchase/Subscription/SubscriptionPurchaseLineItemTest.php
+++ b/tests/Domain/Purchase/Subscription/SubscriptionPurchaseLineItemTest.php
@@ -49,6 +49,9 @@ final class SubscriptionPurchaseLineItemTest extends TestCase
             'signupPromotion' => [
                 'oneTimeCode' => [],
             ],
+            'offerPhase' => [
+                'freeTrial' => [],
+            ],
         ];
 
         $actual = $this->normalizer->normalize($data, SubscriptionPurchaseLineItem::class);
@@ -113,6 +116,8 @@ final class SubscriptionPurchaseLineItemTest extends TestCase
             $actual->autoRenewingPlan->installmentDetails->remainingCommittedPaymentsCount
         );
         $this->assertNotNull($actual->autoRenewingPlan->installmentDetails->pendingCancellation);
+        $this->assertNotNull($actual->offerPhase);
+        $this->assertNotNull($actual->offerPhase->freeTrial);
     }
 
     #[Test]

--- a/tests/Domain/Purchase/Subscription/SubscriptionPurchaseLineItemTest.php
+++ b/tests/Domain/Purchase/Subscription/SubscriptionPurchaseLineItemTest.php
@@ -55,6 +55,9 @@ final class SubscriptionPurchaseLineItemTest extends TestCase
             'signupPromotion' => [
                 'oneTimeCode' => [],
             ],
+            'offerPhase' => [
+                'freeTrial' => [],
+            ],
         ];
 
         $actual = $this->normalizer->normalize($data, SubscriptionPurchaseLineItem::class);
@@ -123,6 +126,8 @@ final class SubscriptionPurchaseLineItemTest extends TestCase
             $actual->autoRenewingPlan->installmentDetails->remainingCommittedPaymentsCount
         );
         $this->assertNotNull($actual->autoRenewingPlan->installmentDetails->pendingCancellation);
+        $this->assertNotNull($actual->offerPhase);
+        $this->assertNotNull($actual->offerPhase->freeTrial);
     }
 
     #[Test]


### PR DESCRIPTION
| Q             | A                                                        |
|---------------|----------------------------------------------------------|
| Tickets       | Fix #306  |
| License       | MIT                                                      |

Add support for [`OfferPhase`](https://developers.google.com/android-publisher/api-ref/rest/v3/purchases.subscriptionsv2#offerphase) of [`SubscriptionPurchaseLineItem`](https://developers.google.com/android-publisher/api-ref/rest/v3/purchases.subscriptionsv2#subscriptionpurchaselineitem) object.
